### PR TITLE
Backwards-compatible fix for `anchestors` typo in Node class

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *.egg-info/
+*.eggs/
 *.pyc
 *.sublime-workspace
 .coverage

--- a/anytree/node.py
+++ b/anytree/node.py
@@ -194,6 +194,15 @@ class NodeMixin(object):
         return self._path[:-1]
 
     @property
+    def ancestors(self):
+        """
+        All parent nodes and their parent nodes.
+
+        This is simply a fix for the `anchestors` typo.
+        """
+        return self.anchestors
+
+    @property
     def descendants(self):
         """
         All child nodes and all their child nodes.

--- a/setup.py
+++ b/setup.py
@@ -40,6 +40,7 @@ config['extras_require'] = {
     'dev': ['check-manifest'],
     'test': ['coverage'],
 }
+config['tests_require'] = ['nose']
 config['test_suite'] = 'nose.collector'
 
 # Get the long description from the README file

--- a/tests/test_node.py
+++ b/tests/test_node.py
@@ -170,6 +170,11 @@ def test_anchestors():
     eq_(s1ca.anchestors, tuple([root, s1, s1c]))
 
 
+def test_ancestors():
+    """Node.ancestors."""
+    test_anchestors()
+
+
 def test_descendants():
     """Node.descendants."""
     root = Node("root")


### PR DESCRIPTION
Added `ancestors` property to Node that simply calls existing `anchestors` method and added a test for it. 

Updated setup.py to require nose to run tests.  

Updated .gitignore to ignore *.eggs/ directories.