### PR TITLE
fix bug of unicode path search

### DIFF
--- a/anytree/resolver.py
+++ b/anytree/resolver.py
@@ -79,7 +79,7 @@ class Resolver(object):
     def __get(self, node, name):
         for child in node.children:
             child_name = _getattr(child, self.pathattr)
-            if isinstance(name, str) and isinstance(child_name, bytes) and type(bytes) != type(str):
+            if isinstance(name, str) and isinstance(child_name, bytes) and bytes != str:
                 name = name.encode('utf-8')
             if child_name == name:
                 return child

--- a/anytree/resolver.py
+++ b/anytree/resolver.py
@@ -78,7 +78,10 @@ class Resolver(object):
 
     def __get(self, node, name):
         for child in node.children:
-            if _getattr(child, self.pathattr) == name:
+            child_name = _getattr(child, self.pathattr)
+            if isinstance(name, str) and isinstance(child_name, bytes) and type(bytes) != type(str):
+                name = name.encode('utf-8')
+            if child_name == name:
                 return child
         raise ChildResolverError(node, name, self.pathattr)
 


### PR DESCRIPTION
fix bug when search unicode path with Python 3 (`bytes` and `str` are not equal in Python 3)