### PR TITLE
Fixed NodeMixin Example

### DIFF
--- a/anytree/node.py
+++ b/anytree/node.py
@@ -22,7 +22,7 @@ class NodeMixin(object):
     If `None` the :any:`NodeMixin` is root node.
     If set to another node, the :any:`NodeMixin` becomes the child of it.
 
-    >>> from anytree import Node, RenderTree
+    >>> from anytree import NodeMixin, RenderTree
     >>> class MyBaseClass(object):
     ...     foo = 4
     >>> class MyClass(MyBaseClass, NodeMixin):  # Add Node feature


### PR DESCRIPTION
I replaced "import Node" with "import NodeMixin" in the NodeMixin example.

This was necessary for me to get the example to work when I first used anytree.

I am new to Python and GitHub, so apologies if it is my mistake and this is not necessary.

Thank you for anytree! It is a very nice package.