### PR TITLE
remove an invalid escape sequence

### DIFF
--- a/anytree/resolver.py
+++ b/anytree/resolver.py
@@ -219,7 +219,7 @@ class Resolver(object):
                 re_pat += "."
             else:
                 re_pat += re.escape(char)
-        return re_pat + '\Z(?ms)'
+        return re_pat + r'\Z(?ms)'
 
 
 class ResolverError(RuntimeError):


### PR DESCRIPTION
code in current release is raising warnings:

    python3.6/site-packages/anytree/resolver.py:222: DeprecationWarning: invalid escape sequence \Z

I've converted this sequence to a raw string.  