### PR TITLE
spec for six dep

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ config['classifiers'] = [
 ]
 config['keywords'] = 'tree, tree data, treelib, tree walk, tree structure'
 config['packages'] = ['anytree', 'anytree.node', 'anytree.iterators', 'anytree.importer', 'anytree.exporter']
-config['install_requires'] = ['six']
+config['install_requires'] = ['six>=1.9.0']
 config['extras_require'] = {
     'dev': ['check-manifest'],
     'test': ['coverage'],


### PR DESCRIPTION
I had six 1.8.0 installed and got error when pip install anytree

```
  File "...python3.6/site-packages/anytree/render.py", line 151, in <module>
    @six.python_2_unicode_compatible
AttributeError: module 'six' has no attribute 'python_2_unicode_compatible'
```