### PR TITLE
Bugix: DictImporter does not allow other node classes

### DIFF
--- a/anytree/importer/dictimporter.py
+++ b/anytree/importer/dictimporter.py
@@ -35,15 +35,14 @@ class DictImporter(object):
 
     def import_(self, data):
         """Import tree from `data`."""
-        return DictImporter.__import(data)
+        return self.__import(data)
 
-    @staticmethod
-    def __import(data, parent=None):
+    def __import(self, data, parent=None):
         assert isinstance(data, dict)
         assert "parent" not in data
         attrs = dict(data)
         children = attrs.pop("children", [])
-        node = AnyNode(parent=parent, **attrs)
+        node = self.nodecls(parent=parent, **attrs)
         for child in children:
-            DictImporter.__import(child, parent=node)
+            self.__import(child, parent=node)
         return node


### PR DESCRIPTION
When trying to import using a different class besides AnyNode, the code would fail.
This is because DictImporter always returns AnyNode nodes and never makes use of the nodecls variable.

This pull request is an attempt to fix that.