### PR TITLE
Support callables in RenderTree.`by_attr()`

### DIFF
--- a/anytree/render.py
+++ b/anytree/render.py
@@ -248,6 +248,14 @@ class RenderTree(object):
         │   └── a
         │       b
         └── Z
+
+        And can be a function:
+        >>> print(RenderTree(root).by_attr(lambda n: " ".join(n.lines)))
+        c0fe c0de
+        ├── ha ba
+        │   ├── 1 2 3
+        │   └── a b
+        └── Z
         """
         if not isinstance(style, AbstractStyle):
             style = style()
@@ -294,7 +302,7 @@ class RenderTree(object):
         """Return rendered tree with node attribute `attrname`."""
         def get():
             for pre, fill, node in self:
-                attr = getattr(node, attrname, "")
+                attr = attrname(node) if callable(attrname) else getattr(node, attrname, "")
                 if isinstance(attr, (list, tuple)):
                     lines = attr
                 else:


### PR DESCRIPTION
Allow passing in a callable as `attrname` in `RenderTree.by_attr()`
This allows for dealing with complex/nested objects as attributes or
performing complex transformations prior to rendering.