### PR TITLE
Use length of children returned from RenderTree.childiter

### DIFF
--- a/anytree/render.py
+++ b/anytree/render.py
@@ -271,8 +271,9 @@ class RenderTree(object):
         yield RenderTree.__item(node, continues, self.style)
         children = node.children
         if children:
+            children = self.childiter(children)
             lastidx = len(children) - 1
-            for idx, child in enumerate(self.childiter(children)):
+            for idx, child in enumerate(children):
                 for grandchild in self.__next(child, continues + (idx != lastidx, )):
                     yield grandchild
 


### PR DESCRIPTION
This is just a small fix, but it allows to use the `childiter` function to not just sort, but also filter nodes when rendering.
I need to "hide" some node types when rendering, and thus do this in childiter:

```py
    def childiter(items):
        items = [i for i in items if i.type in lbuild.format.SHOW_NODES]
        return sorted(items, key=lambda item: (item.type, item.name))
```
However, this renders an additional node line without the node:
```
    ├── Module(modm:build)   Build System Generators
    │   ├── Module(modm:build:scons)   SCons Build Script Generator
    │   │   ╰── EnumerationOption(info.git) = Disabled in [Disabled, Info, Info+Status]
    ├── Module(modm:cmsis)   ARM CMSIS Support
```

After this fix:
```
    ├── Module(modm:build)   Build System Generators
    │   ╰── Module(modm:build:scons)   SCons Build Script Generator
    │       ╰── EnumerationOption(info.git) = Disabled in [Disabled, Info, Info+Status]
    ├── Module(modm:cmsis)   ARM CMSIS Support
```

cc @c0fec0de 