### PR TITLE
catch uncaught StopIteration in zigzaggroupiter

### DIFF
--- a/anytree/iterators/zigzaggroupiter.py
+++ b/anytree/iterators/zigzaggroupiter.py
@@ -50,5 +50,8 @@ class ZigZagGroupIter(AbstractIter):
             assert len(children) == 1
             _iter = LevelOrderGroupIter(children[0], filter_, stop, maxlevel)
             while True:
-                yield next(_iter)
-                yield tuple(reversed(next(_iter)))
+                try:
+                    yield next(_iter)
+                    yield tuple(reversed(next(_iter)))
+                except StopIteration:
+                    break


### PR DESCRIPTION
nosetests on python 3.7 fails in test_iterators.py at line 148 with
RuntimeError: generator raised StopIteration