### PR TITLE
Update resolver.py

### DIFF
--- a/anytree/resolver.py
+++ b/anytree/resolver.py
@@ -219,7 +219,7 @@ class Resolver(object):
                 re_pat += "."
             else:
                 re_pat += re.escape(char)
-        return re_pat + r'\Z(?ms)'
+        return r'(?ms)' + re_pat + r'\Z'
 
 
 class ResolverError(RuntimeError):


### PR DESCRIPTION
Avoid to throw `/my/path/resolver.py:209: DeprecationWarning: Flags not at the start of the expression 'expr\\Z(?ms)'` in python 3.6