### PR TITLE
setup: include license in the source tarball

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -49,6 +49,7 @@ config['extras_require'] = {
 }
 config['tests_require'] = ['nose']
 config['test_suite'] = 'nose.collector'
+config['data_files'] = [('', ['LICENSE'])]
 
 # Get the long description from the README file
 here = path.abspath(path.dirname(__file__))


### PR DESCRIPTION
The users, in particular various Linux distributions, like to include
the full license text to make sure you're not gonna sue their ass off.