### PR TITLE
Include LICENSE, docs, and tests in PyPI tarball

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,4 @@
+include LICENSE
+include tox.ini
+recursive-include docs *
+recursive-include tests *


### PR DESCRIPTION
In OpenBSD we use the regression tests in order to make sure that updates
work properly and that an update of a dependency doesn't break a package.
Having the regression tests in the PyPI tarball makes that much easier.

While here, include the LICENSE file and the documentation in the docs/ directory.