### PR TITLE
Add maxlevel parameter to RenderTree to limit the depth of printing

### DIFF
--- a/anytree/render.py
+++ b/anytree/render.py
@@ -151,7 +151,7 @@ class DoubleStyle(AbstractStyle):
 @six.python_2_unicode_compatible
 class RenderTree(object):
 
-    def __init__(self, node, style=ContStyle(), childiter=list):
+    def __init__(self, node, style=ContStyle(), childiter=list, maxlevel=None):
         u"""
         Render tree starting at `node`.
 
@@ -257,23 +257,32 @@ class RenderTree(object):
         │   ├── 1 2 3
         │   └── a b
         └── Z
+
+        Maxlevel limits the depth of the tree:
+
+        >>> print(RenderTree(root, maxlevel=2))
+        root
+        ├── sub0
+        └── sub1
         """
         if not isinstance(style, AbstractStyle):
             style = style()
         self.node = node
         self.style = style
         self.childiter = childiter
+        self.maxlevel = maxlevel
 
     def __iter__(self):
         return self.__next(self.node, tuple())
 
-    def __next(self, node, continues):
+    def __next(self, node, continues, level=0):
         yield RenderTree.__item(node, continues, self.style)
         children = node.children
-        if children:
+        level += 1
+        if children and (self.maxlevel is None or level < self.maxlevel):
             children = self.childiter(children)
             for child, is_last in _is_last(children):
-                for grandchild in self.__next(child, continues + (not is_last, )):
+                for grandchild in self.__next(child, continues + (not is_last, ), level=level):
                     yield grandchild
 
     @staticmethod

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -90,6 +90,24 @@ def test_render():
     ]
     eq_(result, expected)
 
+def test_maxlevel():
+    root = anytree.Node("root", lines=["c0fe", "c0de"])
+    s0 = anytree.Node("sub0", parent=root, lines=["ha", "ba"])
+    s0b = anytree.Node("sub0B", parent=s0, lines=["1", "2", "3"])
+    s0a = anytree.Node("sub0A", parent=s0, lines=["a", "b"])
+    s1 = anytree.Node("sub1", parent=root, lines=["Z"])
+
+    r = anytree.RenderTree(root, maxlevel=2)
+    result = [(pre, node) for pre, _, node in r]
+    expected = [
+        (u'', root),
+        (u'├── ', s0),
+        (u'└── ', s1),
+    ]
+    print(expected)
+    print(result)
+    eq_(result, expected)
+
 
 def test_asciistyle():
     style = anytree.AsciiStyle()


### PR DESCRIPTION
Adds a `maxlevel` parameter to `RenderTree` to limit the depth of the printed tree.
Can be useful for large and deep trees.