### PR TITLE
Fix code style and minor awkwardness

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,11 @@
+graft anytree
+graft docs
+graft tests
+
 include LICENSE
 include tox.ini
-recursive-include docs *
-recursive-include tests *
+
+# Sublime Text configuration file
+exclude anytree.sublime-project
+
+global-exclude *.py[cod] __pycache__ *.so *.dylib .DS_Store

--- a/anytree/cachedsearch.py
+++ b/anytree/cachedsearch.py
@@ -20,7 +20,6 @@ except ImportError:
             return wrapped
         return decorator
 
-from anytree.iterators import PreOrderIter
 
 CACHE_SIZE = 32
 

--- a/anytree/exporter/dotexporter.py
+++ b/anytree/exporter/dotexporter.py
@@ -380,6 +380,7 @@ class UniqueDotExporter(DotExporter):
         super(UniqueDotExporter, self).__init__(node, graph=graph, name=name, options=options, indent=indent,
                                                 nodenamefunc=nodenamefunc, nodeattrfunc=nodeattrfunc,
                                                 edgeattrfunc=edgeattrfunc, edgetypefunc=edgetypefunc)
+
     @staticmethod
     def _default_nodenamefunc(node):
         return hex(id(node))

--- a/anytree/iterators/preorderiter.py
+++ b/anytree/iterators/preorderiter.py
@@ -47,5 +47,7 @@ class PreOrderIter(AbstractIter):
             if filter_(child_):
                 yield child_
             if not AbstractIter._abort_at_level(2, maxlevel):
-                for descendant_ in PreOrderIter._iter(child_.children, filter_, stop, maxlevel - 1 if maxlevel else None):
+                for descendant_ in PreOrderIter._iter(
+                    child_.children, filter_, stop, maxlevel - 1 if maxlevel else None
+                ):
                     yield descendant_

--- a/anytree/node/nodemixin.py
+++ b/anytree/node/nodemixin.py
@@ -123,7 +123,7 @@ class NodeMixin(object):
     @parent.setter
     def parent(self, value):
         if value is not None and not isinstance(value, NodeMixin):
-            msg = "Parent node %r is not of type 'NodeMixin'." % (value)
+            msg = "Parent node %r is not of type 'NodeMixin'." % value
             raise TreeError(msg)
         try:
             parent = self.__parent
@@ -158,7 +158,9 @@ class NodeMixin(object):
         if parent is not None:
             self._pre_attach(parent)
             parentchildren = parent.__children_
-            assert not any(child is self for child in parentchildren), "Tree internal data is corrupt."  # pragma: no cover
+            assert not any(
+                child is self for child in parentchildren
+            ), "Tree internal data is corrupt."  # pragma: no cover
             # ATOMIC START
             parentchildren.append(self)
             self.__parent = parent
@@ -229,8 +231,7 @@ class NodeMixin(object):
         seen = set()
         for child in children:
             if not isinstance(child, NodeMixin):
-                msg = ("Cannot add non-node object %r. "
-                       "It is not a subclass of 'NodeMixin'.") % child
+                msg = "Cannot add non-node object %r. It is not a subclass of 'NodeMixin'." % child
                 raise TreeError(msg)
             if child not in seen:
                 seen.add(child)

--- a/anytree/render.py
+++ b/anytree/render.py
@@ -13,12 +13,10 @@ import collections
 
 import six
 
-
 Row = collections.namedtuple("Row", ("pre", "fill", "node"))
 
 
 class AbstractStyle(object):
-
     def __init__(self, vertical, cont, end):
         """
         Tree Render Style.
@@ -35,9 +33,11 @@ class AbstractStyle(object):
         self.vertical = vertical
         self.cont = cont
         self.end = end
-        assert (len(cont) == len(vertical) and len(cont) == len(end)), (
-            "'%s', '%s' and '%s' need to have equal length" % (vertical, cont,
-                                                               end))
+        assert len(cont) == len(vertical) == len(end), "'%s', '%s' and '%s' need to have equal length" % (
+            vertical,
+            cont,
+            end,
+        )
 
     @property
     def empty(self):
@@ -50,7 +50,6 @@ class AbstractStyle(object):
 
 
 class AsciiStyle(AbstractStyle):
-
     def __init__(self):
         """
         Ascii style.
@@ -73,7 +72,6 @@ class AsciiStyle(AbstractStyle):
 
 
 class ContStyle(AbstractStyle):
-
     def __init__(self):
         u"""
         Continued style, without gaps.
@@ -98,7 +96,6 @@ class ContStyle(AbstractStyle):
 
 
 class ContRoundStyle(AbstractStyle):
-
     def __init__(self):
         u"""
         Continued style, without gaps, round edges.
@@ -123,7 +120,6 @@ class ContRoundStyle(AbstractStyle):
 
 
 class DoubleStyle(AbstractStyle):
-
     def __init__(self):
         u"""
         Double line style, without gaps.
@@ -150,7 +146,6 @@ class DoubleStyle(AbstractStyle):
 
 @six.python_2_unicode_compatible
 class RenderTree(object):
-
     def __init__(self, node, style=ContStyle(), childiter=list):
         u"""
         Render tree starting at `node`.
@@ -273,7 +268,7 @@ class RenderTree(object):
         if children:
             children = self.childiter(children)
             for child, is_last in _is_last(children):
-                for grandchild in self.__next(child, continues + (not is_last, )):
+                for grandchild in self.__next(child, continues + (not is_last,)):
                     yield grandchild
 
     @staticmethod
@@ -300,7 +295,7 @@ class RenderTree(object):
         return "%s(%s)" % (classname, ", ".join(args))
 
     def by_attr(self, attrname="name"):
-        """
+        u"""
         Return rendered tree with node attribute `attrname`.
 
         >>> from anytree import AnyNode, RenderTree
@@ -324,7 +319,6 @@ class RenderTree(object):
             └── sub1C
                 └── sub1Ca
 
-
         """
         def get():
             for pre, fill, node in self:
@@ -336,6 +330,7 @@ class RenderTree(object):
                 yield u"%s%s" % (pre, lines[0])
                 for line in lines[1:]:
                     yield u"%s%s" % (fill, line)
+
         return "\n".join(get())
 
 

--- a/anytree/search.py
+++ b/anytree/search.py
@@ -1,7 +1,7 @@
 """
 Node Searching.
 
-.. note:: You can speed-up node searching, by installing https://pypi.org/project/fastcache/ and 
+.. note:: You can speed-up node searching, by installing https://pypi.org/project/fastcache/ and
           using :any:`cachedsearch`.
 """
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -31,7 +31,7 @@ Any Python Tree Data
 
 Simple, lightweight and extensible Tree_ data structure.
 
-Feel free to share_ infos about your anytree project.
+Feel free to share_ info about your anytree project.
 
 .. _share: https://github.com/c0fec0de/anytree/issues/34
 

--- a/docs/intro.rst
+++ b/docs/intro.rst
@@ -163,9 +163,9 @@ _post_detach NotifiedNode('/b')
 
 
 .. important::
-    An exeception raised by :any:`_pre_detach(parent)` and :any:`_pre_attach(parent)` will **prevent** the tree structure to be updated.
+    An exception raised by :any:`_pre_detach(parent)` and :any:`_pre_attach(parent)` will **prevent** the tree structure to be updated.
     The node keeps the old state.
-    An exeception raised by :any:`_post_detach(parent)` and :any:`_post_attach(parent)` does **not rollback** the tree structure modification.
+    An exception raised by :any:`_post_detach(parent)` and :any:`_post_attach(parent)` does **not rollback** the tree structure modification.
 
 
 Custom Separator

--- a/docs/tricks/multidim.rst
+++ b/docs/tricks/multidim.rst
@@ -19,7 +19,7 @@ representations in the corresponding trees.
 ...         self.x = None
 ...         self.y = None
 ...     def __repr__(self):
-...         return "Item(%r)" % (self.name)
+...         return "Item(%r)" % self.name
 >>> a = Item('A')
 >>> b = Item('B')
 >>> c = Item('C')

--- a/tox.ini
+++ b/tox.ini
@@ -15,7 +15,7 @@ deps =
     pep257
     nose
 commands =
-    check-manifest --ignore tox.ini,tests*
+    check-manifest {toxinidir}
     python setup.py check -m -r -s
     nosetests .
     flake8 anytree


### PR DESCRIPTION
The code style checker reveals some warning.

The purpose of this PR is to solve some code style issues and correct the MANIFEST.in and Tox.ini files.

Correct the rules in `MANIFEST.in` used to build a sdist package: ignore IDE configuration files and other temporary files (compiled files, caches, etc.).

Correct the Tox configuration file: check-manifest should be called without parameter because they are already defined in the `setup.cfg` file.

Code style fixes:

- `anytree/cachedsearch.py`: Remove unused import `anytree.iterators.PreOrderIter`.
- `anytree/render.py`: fix W292 no newline at end of file and fix D202: No blank lines allowed after function docstring.
- `anytree/search.py`: fix W291 trailing whitespace
- `anytree/iterators/preorderiter.py` and `anytree/node/nodemixin.py`: fix E501 line too long
- `anytree/exporter/dotexporter.py`: fix E301 expected 1 blank line.

