### PR TITLE
Case insensitive resolver

### DIFF
--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -103,6 +103,17 @@ def test_same_name():
     eq_(r.glob(root, "sub"), [sub0, sub1])
 
 
+def test_case_insensitive():
+    """ Case insensitive resolver """
+    root = at.Node("root")
+    sub0 = at.Node("sub0", parent=root)
+    sub1 = at.Node("sub1", parent=root)
+    r = at.Resolver(case_insensitive=True)
+
+    eq_(r.get(root, "SUB0"), sub0)
+    eq_(r.glob(root, "SU*1"), [sub1])
+
+
 def test_enum():
     class Animals(IntEnum):
         Mammal = 1


### PR DESCRIPTION
Adds a `case_insensitive` parameter to `Resolver`.

``` python
r = Resolver('name', case_insensitive=True)
r.get(top, '/TOp')
# => Node('/top')
```