### PR TITLE
Remove try-except overload to check if some attribute exists

### DIFF
--- a/anytree/node/nodemixin.py
+++ b/anytree/node/nodemixin.py
@@ -115,9 +115,9 @@ class NodeMixin(object):
         >>> marc.is_root
         True
         """
-        try:
+        if hasattr(self, "__parent"):
             return self.__parent
-        except AttributeError:
+        else:
             return None
 
     @parent.setter
@@ -125,9 +125,9 @@ class NodeMixin(object):
         if value is not None and not isinstance(value, NodeMixin):
             msg = "Parent node %r is not of type 'NodeMixin'." % (value, )
             raise TreeError(msg)
-        try:
+        if hasattr(self, "__parent"):
             parent = self.__parent
-        except AttributeError:
+        else:
             parent = None
         if parent is not value:
             self.__check_loop(value)
@@ -167,9 +167,9 @@ class NodeMixin(object):
 
     @property
     def __children_or_empty(self):
-        try:
+        if hasattr(self, "__children"):
             return self.__children
-        except AttributeError:
+        else:
             self.__children = []
             return self.__children
 

--- a/anytree/node/nodemixin.py
+++ b/anytree/node/nodemixin.py
@@ -161,11 +161,7 @@ class NodeMixin(object):
 
     @property
     def __children_or_empty(self):
-        if hasattr(self, "__children"):
-            return self.__children
-        else:
-            self.__children = []
-            return self.__children
+        return getattr(self, "__children", [])
 
     @property
     def children(self):

--- a/anytree/node/nodemixin.py
+++ b/anytree/node/nodemixin.py
@@ -115,20 +115,14 @@ class NodeMixin(object):
         >>> marc.is_root
         True
         """
-        if hasattr(self, "__parent"):
-            return self.__parent
-        else:
-            return None
+        return getattr(self, "__parent", None)
 
     @parent.setter
     def parent(self, value):
         if value is not None and not isinstance(value, NodeMixin):
             msg = "Parent node %r is not of type 'NodeMixin'." % (value, )
             raise TreeError(msg)
-        if hasattr(self, "__parent"):
-            parent = self.__parent
-        else:
-            parent = None
+        parent = getattr(self, "__parent", None)
         if parent is not value:
             self.__check_loop(value)
             self.__detach(parent)

--- a/anytree/node/nodemixin.py
+++ b/anytree/node/nodemixin.py
@@ -115,14 +115,20 @@ class NodeMixin(object):
         >>> marc.is_root
         True
         """
-        return getattr(self, "__parent", None)
+        if hasattr(self, "_NodeMixin__parent"):
+            return self.__parent
+        else:
+            return None
 
     @parent.setter
     def parent(self, value):
         if value is not None and not isinstance(value, NodeMixin):
             msg = "Parent node %r is not of type 'NodeMixin'." % (value, )
             raise TreeError(msg)
-        parent = getattr(self, "__parent", None)
+        if hasattr(self, "_NodeMixin__parent"):
+            parent = self.__parent
+        else:
+            parent = None
         if parent is not value:
             self.__check_loop(value)
             self.__detach(parent)
@@ -161,7 +167,11 @@ class NodeMixin(object):
 
     @property
     def __children_or_empty(self):
-        return getattr(self, "__children", [])
+        if hasattr(self, "_NodeMixin__children"):
+            return self.__children
+        else:
+            self.__children = []
+            return self.__children
 
     @property
     def children(self):

--- a/anytree/search.py
+++ b/anytree/search.py
@@ -227,9 +227,9 @@ def _findall(node, filter_, stop=None, maxlevel=None, mincount=None, maxcount=No
 
 
 def _filter_by_name(node, name, value):
-    if hasattr(node, name):
+    try:
         return getattr(node, name) == value
-    else:
+    except AttributeError:
         return False
 
 

--- a/anytree/search.py
+++ b/anytree/search.py
@@ -227,9 +227,9 @@ def _findall(node, filter_, stop=None, maxlevel=None, mincount=None, maxcount=No
 
 
 def _filter_by_name(node, name, value):
-    try:
+    if hasattr(node, name):
         return getattr(node, name) == value
-    except AttributeError:
+    else:
         return False
 
 


### PR DESCRIPTION
In the current implementation, there are some try-except blocks to check if an object has some attribute. To reduce the generated overhead by the exception handling logic, I propose to start using the `getattr` builtin function with a default value instead.

This change doesn't provide a big performance improvement, but it's a constant-factor cost removal with no public API implications.

To check the difference, I build a `1` million node random tree with a height of `25`. The logic to build the `anynode.AnyNode` instances from the tree encoded as raw dictionaries decreased from `~11` seconds to `~8` seconds on my computer (not a big change, but better than nothing 🙂). 