### PR TITLE
fix typos in the `AnyNode` and `Node` docstrings

### DIFF
--- a/anytree/node/anynode.py
+++ b/anytree/node/anynode.py
@@ -15,7 +15,7 @@ class AnyNode(NodeMixin, object):
             children: Iterable with child nodes.
             *: Any other given attribute is just stored as object attribute.
 
-        Other than :any:`Node` this class has no default idenifier.
+        Other than :any:`Node` this class has no default identifier.
         It is up to the user to use other attributes for identification.
 
         The `parent` attribute refers the parent node:

--- a/anytree/node/node.py
+++ b/anytree/node/node.py
@@ -11,7 +11,7 @@ class Node(NodeMixin, object):
         A simple tree node with a `name` and any `kwargs`.
 
         Args:
-            name: A name or any other object this node can reference to as idendifier.
+            name: A name or any other object this node can reference to as identifier.
 
         Keyword Args:
             parent: Reference to parent node.


### PR DESCRIPTION
'idendifier' -> identifier 