### PR TITLE
fix that allows for deepcopy/pickling trees with symlink nodes

### DIFF
--- a/anytree/node/symlinknodemixin.py
+++ b/anytree/node/symlinknodemixin.py
@@ -48,6 +48,8 @@ class SymlinkNodeMixin(NodeMixin):
     def __getattr__(self, name):
         if name in ("_NodeMixin__parent", "_NodeMixin__children"):
             return super(SymlinkNodeMixin, self).__getattr__(name)
+        elif name == '__setstate__':
+            raise AttributeError(name)
         return getattr(self.target, name)
 
     def __setattr__(self, name, value):


### PR DESCRIPTION
Fixes https://github.com/c0fec0de/anytree/issues/138 and possibly https://github.com/c0fec0de/anytree/issues/161. Also fixes the infinite recursion error in `copy.deepcopy(tree)` when `tree` has a `SymlinkNode`.