### PR TITLE
a mistake in anynode docs

### DIFF
--- a/anytree/node/anynode.py
+++ b/anytree/node/anynode.py
@@ -81,7 +81,7 @@ class AnyNode(NodeMixin, object):
         >>> print(RenderTree(root))
         AnyNode(id='root', new='a new attribute')
         ├── AnyNode(id='sub0')
-        │   ├── AnyNode(bar=109, foo=4, id='sub0B')
+        │   ├── AnyNode(bar=110, foo=4, id='sub0B')
         │   └── AnyNode(id='sub0A')
         └── AnyNode(id='sub1')
             ├── AnyNode(id='sub1A')


### PR DESCRIPTION
a mistake in anynode docs

after this command `s0b.bar = 110  # modified`,

`AnyNode(bar=109, foo=4, id='sub0B')` should change to 
`AnyNode(bar=110, foo=4, id='sub0B')`