### PR TITLE
Switch to use `ruff`

### DIFF
--- a/anytree/exporter/mermaidexporter.py
+++ b/anytree/exporter/mermaidexporter.py
@@ -197,8 +197,7 @@ class MermaidExporter:
     def __iter_nodes(self, indent, nodenamefunc, nodefunc, filter_, stop):
         for node in PreOrderIter(self.node, filter_=filter_, stop=stop, maxlevel=self.maxlevel):
             nodename = nodenamefunc(node)
-            node = nodefunc(node)
-            yield "%s%s%s" % (indent, nodename, node)
+            yield "%s%s%s" % (indent, nodename, nodefunc(node))
 
     def __iter_edges(self, indent, nodenamefunc, edgefunc, filter_, stop):
         maxlevel = self.maxlevel - 1 if self.maxlevel else None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -114,10 +114,10 @@ setenv =
 commands =
     poetry install --with=test --with=doc
     poetry run black .
+    poetry run ruff check anytree
     poetry run coverage run --source=anytree --branch -m pytest --doctest-glob=docs/*.rst --doctest-modules --ignore-glob=tests/testdata* --ignore=docs/conf.py --log-level=DEBUG -vv --junitxml=report.xml
     poetry run coverage report
     poetry run coverage html
     poetry run coverage xml
-    poetry run ruff check anytree
     poetry run make html -C docs
 """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ six = '*'
 black = '^22.3.0'
 coverage = '^6.4.4'
 isort = '^5.9'
-pylint = '^2.15'
+ruff = '^0.1.13'
 pytest = '^6.2'
 pyyaml = ">=6.0"
 
@@ -79,18 +79,22 @@ exclude_lines = [
 ]
 
 
-[tool.pylint.'MESSAGES CONTROL']
-max-line-length = 120
-disable = [
-    'consider-using-f-string',
-    'duplicate-code',
-    'missing-class-docstring',
-    'missing-module-docstring',
-    'redundant-u-string-prefix',
-    'too-few-public-methods',
-    'too-many-arguments',
-    'too-many-instance-attributes',
-    'super-with-arguments', # TBD
+[tool.ruff]
+line-length = 120
+fix = true
+
+include = ["*.py", "*.pyi", "**/pyproject.toml"]
+select = [
+    "PL",  # Pylint
+]
+extend-ignore = [
+    "UP031",   # printf-string-formatting
+    "UP032",   # f-string
+    "D101",    # undocumented-public-class
+    "D100",    # undocumented-public-module
+    "PLR0912", # too-many-branches
+    "PLR0913", # too-many-arguments
+    "UP008",   # super-call-with-parameters  # TBD
 ]
 
 [tool.tox]
@@ -115,6 +119,6 @@ commands =
     poetry run coverage report
     poetry run coverage html
     poetry run coverage xml
-    poetry run pylint anytree
+    poetry run ruff check anytree
     poetry run make html -C docs
 """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,6 @@ six = '*'
 [tool.poetry.group.test.dependencies]
 black = '^22.3.0'
 coverage = '^6.4.4'
-isort = '^5.9'
 ruff = '^0.1.13'
 pytest = '^6.2'
 pyyaml = ">=6.0"
@@ -49,6 +48,10 @@ sphinx = '*'
 [build-system]
 requires = ["poetry_core>=1.0"]
 build-backend = "poetry.core.masonry.api"
+
+
+[tool.ruff.isort]
+combine-as-imports = true
 
 
 [tool.black]
@@ -67,10 +70,6 @@ exclude = '''
 )/
 '''
 
-[tool.isort]
-profile = "black"
-line_length = 120
-
 [tool.coverage.report]
 exclude_lines = [
     'return NotImplemented',
@@ -86,6 +85,7 @@ fix = true
 include = ["*.py", "*.pyi", "**/pyproject.toml"]
 select = [
     "PL",  # Pylint
+    "I",   # isort
 ]
 extend-ignore = [
     "UP031",   # printf-string-formatting
@@ -114,7 +114,6 @@ setenv =
 commands =
     poetry install --with=test --with=doc
     poetry run black .
-    poetry run isort .
     poetry run coverage run --source=anytree --branch -m pytest --doctest-glob=docs/*.rst --doctest-modules --ignore-glob=tests/testdata* --ignore=docs/conf.py --log-level=DEBUG -vv --junitxml=report.xml
     poetry run coverage report
     poetry run coverage html


### PR DESCRIPTION
This pull request has the project switch to using ruff instead of pyflakes and handles the slight differences it has.
I was considering moving this into another pull request to follow this one, but I also switched to using ruff's integrated version of isort as well.

They have a quite compelling advertisement of sorts of why you should use their system in [their readme](https://github.com/astral-sh/ruff#readme), but in the end I am suggesting to switch to ruff because it's got nearly all the warnings flake8 does but also has autofix support, and it's way faster.

https://github.com/astral-sh/ruff/issues/970 is tracking pyflakes re-implementation progress, and using ruff opens the door to enabling even more checks in the future with almost no performance loss for doing so.