### PR TITLE
Partial recursion unrolling for PreOrderIter

### DIFF
--- a/src/anytree/iterators/preorderiter.py
+++ b/src/anytree/iterators/preorderiter.py
@@ -1,4 +1,5 @@
 from .abstractiter import AbstractIter
+from collections import deque
 
 
 class PreOrderIter(AbstractIter):
@@ -40,11 +41,19 @@ class PreOrderIter(AbstractIter):
 
     @staticmethod
     def _iter(children, filter_, stop, maxlevel):
-        for child_ in children:
+        cur_children = deque(children)
+        descendantmaxlevel = maxlevel
+        while cur_children:
+            child_ = cur_children.popleft()
             if stop(child_):
                 continue
             if filter_(child_):
                 yield child_
-            if not AbstractIter._abort_at_level(2, maxlevel):
-                descendantmaxlevel = maxlevel - 1 if maxlevel else None
-                yield from PreOrderIter._iter(child_.children, filter_, stop, descendantmaxlevel)
+            if not AbstractIter._abort_at_level(2, descendantmaxlevel):
+                descendantmaxlevel = descendantmaxlevel - 1 if descendantmaxlevel else None
+                if len(child_.children) == 1:
+                    cur_children.appendleft(child_.children[0])
+                    continue
+                else:
+                    yield from PreOrderIter._iter(child_.children, filter_, stop, descendantmaxlevel)
+            descendantmaxlevel = maxlevel

--- a/src/anytree/iterators/preorderiter.py
+++ b/src/anytree/iterators/preorderiter.py
@@ -53,6 +53,5 @@ class PreOrderIter(AbstractIter):
                 if len(child_.children) == 1:
                     cur_children.append(child_.children[0])
                     continue
-                else:
-                    yield from PreOrderIter._iter(child_.children, filter_, stop, descendantmaxlevel)
+                yield from PreOrderIter._iter(child_.children, filter_, stop, descendantmaxlevel)
             descendantmaxlevel = maxlevel

--- a/src/anytree/iterators/preorderiter.py
+++ b/src/anytree/iterators/preorderiter.py
@@ -1,5 +1,4 @@
 from .abstractiter import AbstractIter
-from collections import deque
 
 
 class PreOrderIter(AbstractIter):
@@ -41,10 +40,10 @@ class PreOrderIter(AbstractIter):
 
     @staticmethod
     def _iter(children, filter_, stop, maxlevel):
-        cur_children = deque(children)
+        cur_children = list(reversed(children))
         descendantmaxlevel = maxlevel
         while cur_children:
-            child_ = cur_children.popleft()
+            child_ = cur_children.pop()
             if stop(child_):
                 continue
             if filter_(child_):
@@ -52,7 +51,7 @@ class PreOrderIter(AbstractIter):
             if not AbstractIter._abort_at_level(2, descendantmaxlevel):
                 descendantmaxlevel = descendantmaxlevel - 1 if descendantmaxlevel else None
                 if len(child_.children) == 1:
-                    cur_children.appendleft(child_.children[0])
+                    cur_children.append(child_.children[0])
                     continue
                 else:
                     yield from PreOrderIter._iter(child_.children, filter_, stop, descendantmaxlevel)

--- a/tests/test_iterators.py
+++ b/tests/test_iterators.py
@@ -31,7 +31,7 @@ def test_preorder():
     eq_(list(PreOrderIter(f, maxlevel=2)), [f, b, g])
     eq_(list(PreOrderIter(f, maxlevel=3)), [f, b, a, d, g, i])
     eq_(list(PreOrderIter(f, maxlevel=4)), [f, b, a, k, d, c, e, g, i, h])
-    eq_(list(PreOrderIter(f, maxlevel=5)), list(PreOrderIter(f)))
+    eq_(list(PreOrderIter(f, maxlevel=f.height + 1)), list(PreOrderIter(f)))
     eq_(list(PreOrderIter(f, filter_=lambda n: n.name not in ("e", "g"))), [f, b, a, k, o, d, c, m, i, h])
     eq_(list(PreOrderIter(f, stop=lambda n: n.name == "d")), [f, b, a, k, o, g, i, h])
 

--- a/tests/test_iterators.py
+++ b/tests/test_iterators.py
@@ -23,22 +23,22 @@ def test_preorder():
     i = Node("i", parent=g)
     h = Node("h", parent=i)
     k = Node("k", parent=a)
-    l = Node("l", parent=k)
+    o = Node("o", parent=k)
     m = Node("m", parent=e)
 
-    eq_(list(PreOrderIter(f)), [f, b, a, k, l, d, c, e, m, g, i, h])
+    eq_(list(PreOrderIter(f)), [f, b, a, k, o, d, c, e, m, g, i, h])
     eq_(list(PreOrderIter(f, maxlevel=0)), [])
     eq_(list(PreOrderIter(f, maxlevel=2)), [f, b, g])
     eq_(list(PreOrderIter(f, maxlevel=3)), [f, b, a, d, g, i])
     eq_(list(PreOrderIter(f, maxlevel=4)), [f, b, a, k, d, c, e, g, i, h])
     eq_(list(PreOrderIter(f, maxlevel=5)), list(PreOrderIter(f)))
-    eq_(list(PreOrderIter(f, filter_=lambda n: n.name not in ("e", "g"))), [f, b, a, k, l, d, c, m, i, h])
-    eq_(list(PreOrderIter(f, stop=lambda n: n.name == "d")), [f, b, a, k, l, g, i, h])
+    eq_(list(PreOrderIter(f, filter_=lambda n: n.name not in ("e", "g"))), [f, b, a, k, o, d, c, m, i, h])
+    eq_(list(PreOrderIter(f, stop=lambda n: n.name == "d")), [f, b, a, k, o, g, i, h])
 
     it = PreOrderIter(f)
     eq_(next(it), f)
     eq_(next(it), b)
-    eq_(list(it), [a, k, l, d, c, e, m, g, i, h])
+    eq_(list(it), [a, k, o, d, c, e, m, g, i, h])
 
 
 def test_postorder():

--- a/tests/test_iterators.py
+++ b/tests/test_iterators.py
@@ -22,17 +22,23 @@ def test_preorder():
     g = Node("g", parent=f)
     i = Node("i", parent=g)
     h = Node("h", parent=i)
+    k = Node("k", parent=a)
+    l = Node("l", parent=k)
+    m = Node("m", parent=e)
 
-    eq_(list(PreOrderIter(f)), [f, b, a, d, c, e, g, i, h])
+    eq_(list(PreOrderIter(f)), [f, b, a, k, l, d, c, e, m, g, i, h])
     eq_(list(PreOrderIter(f, maxlevel=0)), [])
+    eq_(list(PreOrderIter(f, maxlevel=2)), [f, b, g])
     eq_(list(PreOrderIter(f, maxlevel=3)), [f, b, a, d, g, i])
-    eq_(list(PreOrderIter(f, filter_=lambda n: n.name not in ("e", "g"))), [f, b, a, d, c, i, h])
-    eq_(list(PreOrderIter(f, stop=lambda n: n.name == "d")), [f, b, a, g, i, h])
+    eq_(list(PreOrderIter(f, maxlevel=4)), [f, b, a, k, d, c, e, g, i, h])
+    eq_(list(PreOrderIter(f, maxlevel=5)), list(PreOrderIter(f)))
+    eq_(list(PreOrderIter(f, filter_=lambda n: n.name not in ("e", "g"))), [f, b, a, k, l, d, c, m, i, h])
+    eq_(list(PreOrderIter(f, stop=lambda n: n.name == "d")), [f, b, a, k, l, g, i, h])
 
     it = PreOrderIter(f)
     eq_(next(it), f)
     eq_(next(it), b)
-    eq_(list(it), [a, d, c, e, g, i, h])
+    eq_(list(it), [a, k, l, d, c, e, m, g, i, h])
 
 
 def test_postorder():


### PR DESCRIPTION
Occasionally, I have trees that are very degenerate in the sense that they feature an overwhelming majority of "only-child" parents; let's call those trees "sparse" in this context. In my application, the sparseness is inherent already in the physical domain that I model, and is thus costly to avoid in the code. Now, for large trees, important standard operations that build on recursion—such as the iterators—can blow up the Python recursion stack; at the same time, the latter can no longer simply be increased without tricks (see, for example, [this discussion](https://stackoverflow.com/questions/5061582/setting-stacksize-in-a-python-script/16248113#16248113)).

One way to avoid this is to "unroll" all those recursions that are degenerate in that they do not incorporate any branching. I have implemented that in `PreOrderIter` exemplarily, and added some more unit tests that capture cases that haven't been covered before. This *partial* unrolling implementation is a compromise between loop and recursion: of course, the queue (or the stack) approach could be used even more consequently, eliminating all recursion whatsoever. However, this would particularly complicate the "maxlevel" filtering, having it to rely on (more expensive) calls to the `depth` property. At the same time, the most obviously unnecessary recursion is effectively avoided, making the iterator significantly more efficient for sparse—yet large—trees.

One final remark about this pull request: For now, I only updated `PreOrderIter`, for one thing because I mostly use this iterator in my own work, and for another because it is heavily used internally. This latter use is what made me submit this PR: In my understanding, there is no way to "augment" anytree by a new iterator implementation through delegation or inheritance, which also replaces its internal use in standard properties, such as `leaves`, `size`, etc.